### PR TITLE
Fix: literals rendering as illegal parameters

### DIFF
--- a/sqlalchemy_views/views.py
+++ b/sqlalchemy_views/views.py
@@ -49,7 +49,7 @@ def visit_create_view(create, compiler, **kw):
         text += "("
         text += ', '.join(column_names)
         text += ") "
-    text += "AS %s\n\n" % compiler.sql_compiler.process(create.selectable)
+    text += "AS %s\n\n" % compiler.sql_compiler.process(create.selectable, literal_binds=True)
     return text
 
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -52,6 +52,15 @@ def test_view_with_column_names():
     create_view = CreateView(view, selectable)
     assert clean(expected_result) == clean(compile_query(create_view))
 
+def test_view_with_literals():
+    expected_result = """
+    CREATE VIEW myview (col3) AS SELECT 0 AS anon_1
+    """
+    selectable = sa.sql.select((sa.literal(0),))
+    view = Table('myview', sa.MetaData(),
+                 sa.Column('col3', sa.Integer()))
+    create_view = CreateView(view, selectable)
+    assert clean(expected_result) == clean(compile_query(create_view))
 
 def test_view_with_delimited_identifiers():
     expected_result = """


### PR DESCRIPTION
DDL such as `CREATE VIEW` statements typically don't accept parameters, and sqlalchemy normally renders literals as parameters.
This test output illustrates the problem.
```
=============================== FAILURES ===============================
_______________________ test_view_with_literals ________________________

    def test_view_with_literals():
        expected_result = """
        CREATE VIEW myview (col3) AS SELECT 0 AS anon_1
        """
        selectable = sa.sql.select((sa.literal(0),))
        view = Table('myview', sa.MetaData(),
                     sa.Column('col3', sa.Integer()))
        create_view = CreateView(view, selectable)
>       assert clean(expected_result) == clean(compile_query(create_view))
E       AssertionError: assert 'CREATE VIEW ...T 0 AS anon_1' == 'CREATE VIEW m...m_1 AS anon_1'
E         - CREATE VIEW myview (col3) AS SELECT 0 AS anon_1
E         ?                                     ^
E         + CREATE VIEW myview (col3) AS SELECT :param_1 AS anon_1
E         ?                                     ^^^^^^^^

tests/test_views.py:63: AssertionError
================== 1 failed, 3 passed in 0.58 seconds ==================
```
More realistic selectables may contain literals in `WHERE` clauses.

The fix is rather simple: heed the advice in [Cross Compiling between SQL and DDL compilers](https://docs.sqlalchemy.org/en/latest/core/compiler.html#cross-compiling-between-sql-and-ddl-compilers) and employ `literal_binds=True`.
I notice you refer to [this recipe](https://bitbucket.org/zzzeek/sqlalchemy/wiki/UsageRecipes/Views) as design reference, and it does this, so I wonder if `literal_binds=True` was eliminated in consideration to a different problem.
