### PR TITLE
support schema_translate_map in CreateView

### DIFF
--- a/sqlalchemy_views/views.py
+++ b/sqlalchemy_views/views.py
@@ -38,7 +38,7 @@ class CreateView(_CreateDropBase):
 @compiles(CreateView)
 def visit_create_view(create, compiler, **kw):
     view = create.element
-    preparer = compiler.dialect.identifier_preparer
+    preparer = compiler.preparer
     text = "\nCREATE "
     if create.or_replace:
         text += "OR REPLACE "

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -24,10 +24,13 @@ def compile_query(query, **kwargs):
 
 @pytest.mark.parametrize("schema,schema_map,expected_result", [
     (None, None, "CREATE VIEW myview AS SELECT t1.col1, t1.col2 FROM t1"),
-    ('myschema', None, "CREATE VIEW myschema.myview AS SELECT t1.col1, t1.col2 FROM t1"),
+    ('myschema', None, "CREATE VIEW myschema.myview AS SELECT myschema.t1.col1, myschema.t1.col2 FROM myschema.t1"),
     ('myschema', {'myschema': None}, "CREATE VIEW myview AS SELECT t1.col1, t1.col2 FROM t1"),
     ])
 def test_basic_view(schema, schema_map, expected_result):
+    t1 = Table('t1', sa.MetaData(schema=schema),
+               sa.Column('col1', sa.Integer(), primary_key=True),
+               sa.Column('col2', sa.Integer()))
     selectable = sa.sql.select([t1])
     view = Table('myview', sa.MetaData(schema=schema))
     create_view = CreateView(view, selectable)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,5 +1,6 @@
 import re
 
+import pytest
 import sqlalchemy as sa
 from sqlalchemy import Table
 
@@ -15,20 +16,23 @@ def clean(query):
     return re.sub(r'\s+', ' ', query).strip()
 
 
-def compile_query(query):
-    return str(query.compile(
-        compile_kwargs={'literal_binds': True})
-    )
+def compile_query(query, **kwargs):
+    compile_kwargs = {'literal_binds': True}
+    compiled = query.compile(compile_kwargs=compile_kwargs, **kwargs)
+    return str(compiled)
 
 
-def test_basic_view():
-    expected_result = """
-    CREATE VIEW myview AS SELECT t1.col1, t1.col2 FROM t1
-    """
+@pytest.mark.parametrize("schema,schema_map,expected_result", [
+    (None, None, "CREATE VIEW myview AS SELECT t1.col1, t1.col2 FROM t1"),
+    ('myschema', None, "CREATE VIEW myschema.myview AS SELECT t1.col1, t1.col2 FROM t1"),
+    ('myschema', {'myschema': None}, "CREATE VIEW myview AS SELECT t1.col1, t1.col2 FROM t1"),
+    ])
+def test_basic_view(schema, schema_map, expected_result):
     selectable = sa.sql.select([t1])
-    view = Table('myview', sa.MetaData())
+    view = Table('myview', sa.MetaData(schema=schema))
     create_view = CreateView(view, selectable)
-    assert clean(expected_result) == clean(compile_query(create_view))
+    actual = compile_query(create_view, schema_translate_map=schema_map)
+    assert clean(expected_result) == clean(actual)
 
 
 def test_view_replace():


### PR DESCRIPTION
I have changed to the `preparer` in `CreateView` so that it supports the `schema_translate_map`.  
See [SQLAlchemy docs](https://docs.sqlalchemy.org/en/13/core/connections.html#schema-translating) for more details on what this does.

I have also added a parametrized test.