### PR TITLE
support view options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,10 @@ Examples:
     >>> print(str(create_view.compile()).strip())
     CREATE OR REPLACE VIEW my_view AS SELECT * FROM my_table
 
+	>>> create_view = CreateView(view, definition, options={'check_option': 'local'})
+	>>> print(str(create_view.compile()).strip())
+	CREATE VIEW my_view WITH (check_option=local) AS SELECT * FROM my_table
+
     >>> drop_view = DropView(view)
     >>> print(str(drop_view.compile()).strip())
     DROP VIEW my_view

--- a/sqlalchemy_views/views.py
+++ b/sqlalchemy_views/views.py
@@ -23,16 +23,20 @@ class CreateView(_CreateDropBase):
     or_replace: boolean
         If True, this definition will replace an existing definition.
         Otherwise, an exception will be raised if the view exists.
+    options: dict
+        Specify optional parameters for a view. For Postgresql, it translates
+        into 'WITH ( view_option_name [= view_option_value] [, ... ] )'
     """
 
     __visit_name__ = "create_view"
 
     def __init__(self, element, selectable, on=None, bind=None,
-                 or_replace=False):
+                 or_replace=False, options=None):
         super(CreateView, self).__init__(element, on=on, bind=bind)
         self.columns = [CreateColumn(column) for column in element.columns]
         self.selectable = selectable
         self.or_replace = or_replace
+        self.options = options
 
 
 @compiles(CreateView)
@@ -49,6 +53,11 @@ def visit_create_view(create, compiler, **kw):
         text += "("
         text += ', '.join(column_names)
         text += ") "
+    if create.options:
+      ops = []
+      for opname, opval in create.options.items():
+        ops.append('='.join([str(opname), str(opval)]))
+      text += 'WITH (%s) ' % (','.join(ops))
     text += "AS %s\n\n" % compiler.sql_compiler.process(create.selectable, literal_binds=True)
     return text
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -82,6 +82,18 @@ def test_view_with_delimited_identifiers():
     assert clean(expected_result) == clean(compile_query(create_view))
 
 
+def test_view_with_options():
+    expected_result = "CREATE VIEW myview WITH (check_option=local) AS SELECT t1.col1, t1.col2 FROM t1"
+    t1 = Table('t1', sa.MetaData(),
+               sa.Column('col1', sa.Integer(), primary_key=True),
+               sa.Column('col2', sa.Integer()))
+    selectable = sa.sql.select([t1])
+    view = Table('myview', sa.MetaData())
+    create_view = CreateView(view, selectable, options=dict(check_option='local'))
+    actual = compile_query(create_view)
+    assert clean(expected_result) == clean(actual)
+
+
 def test_drop_basic_view():
     expected_result = """
     DROP VIEW myview


### PR DESCRIPTION
The syntax for Postgresql: https://www.postgresql.org/docs/11/sql-createview.html
The usage on pipelinedb: http://docs.pipelinedb.com/quickstart.html