### PR TITLE
Minor update based on changes in SQLAlchemy 2.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,9 +43,9 @@ Examples:
 
 Note that the SQLAlchemy ``Table`` object is used to represent
 both tables and views. To introspect a view, create a ``Table``
-with ``autoload=True``, and then use SQLAlchemy's
-``get_view_definition`` method to generate the second
-argument to ``CreateView``.
+with ``autoload=True`` (or ``autload_with=engine`` in SQLAlchemy 2.0+),
+and then use SQLAlchemy's ``get_view_definition`` method to
+generate the second argument to ``CreateView``.
 
 
 Installation


### PR DESCRIPTION
Apologies for not submitting an issue first, but was hoping this would be minor enough to not need one.

Looks like the `autoload` option to the `Table` constructor [was deprecated in the transition to SQLAlchemy 2.0](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#implicit-and-connectionless-execution-bound-metadata-removed) and the recommended usage is `autoload_with=engine`. I included that new usage alongside the old in the README (mostly to help any new-ish SQLAlchemy users like myself from hunting through the `Table` signature trying to find the non-existent `autoload` parameter 😅).